### PR TITLE
Fix line endings of sprite 0494 and 0494/0000/0001

### DIFF
--- a/sprite/0494/0000/0001/AnimData.xml
+++ b/sprite/0494/0000/0001/AnimData.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" ?>
+<?xml version="1.0" ?>
 <AnimData>
 	<ShadowSize>1</ShadowSize>
 	<Anims>

--- a/sprite/0494/AnimData.xml
+++ b/sprite/0494/AnimData.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" ?>
+<?xml version="1.0" ?>
 <AnimData>
 	<ShadowSize>1</ShadowSize>
 	<Anims>


### PR DESCRIPTION
They had Windows / DOS line endings, when all other files had Unix line endings.